### PR TITLE
Added a handler for allowing path mapping via a callback.

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -19,6 +19,7 @@ const defaultOptions = {
     outputStyle: "compressed",
     sourceMap: null,
     sourceRoot: [],
+    pathResolver: (url) => { return url; }
 };
 const stylesheets = new Map;
 const hashLength = 8;
@@ -47,6 +48,15 @@ const transpile = (scss, filepath, options) => {
                 includePaths: options.includePaths,
                 outFile: outFile,
                 outputStyle: options.outputStyle,
+                importer: (url, file) => {
+                    let resolvedUrl = options.pathResolver(url);
+                    if (resolvedUrl === undefined) {
+                        resolvedUrl = url;
+                    }
+                    return {
+                        file: resolvedUrl
+                    };
+                }
             };
             if (options.sourceMap) {
                 renderOptions = {
@@ -128,7 +138,7 @@ const outputError = (e, filepath = '') => {
     message += `${'-'.repeat(50)}\n`;
     console.log(chalk.bold.red(message));
 };
-const getJsImports = (code, absolutePath) => {
+const getJsImports = (code, absolutePath, pathResolver) => {
     // Needed to fix TypeScript injecting code above imports
     const importStart = code.indexOf('import');
     if (importStart >= 0) {
@@ -136,7 +146,11 @@ const getJsImports = (code, absolutePath) => {
             const p = path.parse(i.fromModule);
             const ext = p.ext ? p.ext.substr(1) : 'js';
             if (['scss', 'sass', 'css', 'ts', 'js'].includes(ext)) {
-                const importPath = getRealPath(p.dir, absolutePath);
+                let filepath = pathResolver(p.dir);
+                if (filepath === undefined) {
+                    filepath = p.dir;
+                }
+                const importPath = getRealPath(filepath, absolutePath);
                 return {
                     name: p.name,
                     type: ext,
@@ -178,9 +192,9 @@ const addModuleToTree = (name, imports, code) => {
         });
     }
 };
-const createTransform = (filter) => (code, id) => {
+const createTransform = (filter, pathResolver) => (code, id) => {
     if (!skipNext) {
-        const imports = getJsImports(code, id);
+        const imports = getJsImports(code, id, pathResolver);
         addModuleToTree(id, imports, code);
     }
     if (!filter(id)) {
@@ -276,7 +290,7 @@ var index = (options = {}) => {
     const filter = pluginutils.createFilter(moduleOptions.include, moduleOptions.exclude);
     return {
         name: 'scss-module-bundler',
-        transform: createTransform(filter),
+        transform: createTransform(filter, moduleOptions.pathResolver),
         watchChange,
         generateBundle: createGenerateBundle(moduleOptions),
         buildStart: () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-sass-module-bundler",
-  "version": "1.0.0-rc3",
+  "version": "1.0.0-rc4",
   "description": "A Rollup plugin for transpiling and bunding sass/scss files using sass modules",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Added ability to map paths from imports, use, statements, etc. This allows us to leverage this plugin in scenarios where we are using path mapping in tsconfig to clean up imports.