### PR TITLE
feat: changing filter for null char to a more generic char

### DIFF
--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -152,7 +152,7 @@ const getJsImports = (code, absolutePath, pathResolver) => {
     const importStart = code.indexOf('import');
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !checkForBom(i.fromModule))
+            .filter(i => !hasBom(i.fromModule))
             .map(i => {
             const p = path.parse(i.fromModule);
             const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -294,8 +294,8 @@ const getBundleName = (bundle) => {
     }
     return '';
 };
-const checkForBom = (module) => {
-    if (module.startsWith('\0')) {
+const hasBom = (module) => {
+    if (!module.search(/\0/)) {
         return true;
     }
     return false;

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -152,7 +152,7 @@ const getJsImports = (code, absolutePath, pathResolver) => {
     const importStart = code.indexOf('import');
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !i.fromModule.startsWith('\\u0000'))
+            .filter(i => !checkForBom(i.fromModule))
             .map(i => {
             const p = path.parse(i.fromModule);
             const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -293,6 +293,12 @@ const getBundleName = (bundle) => {
         return bundle[key].fileName;
     }
     return '';
+};
+const checkForBom = (module) => {
+    if (module.startsWith('\0')) {
+        return true;
+    }
+    return false;
 };
 var index = (options = {}) => {
     const moduleOptions = {

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -150,7 +150,7 @@ const getJsImports = (code, absolutePath, pathResolver) => {
     const importStart = code.indexOf('import');
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !i.fromModule.startsWith('\\u0000'))
+            .filter(i => !checkForBom(i.fromModule))
             .map(i => {
             const p = path.parse(i.fromModule);
             const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -291,6 +291,12 @@ const getBundleName = (bundle) => {
         return bundle[key].fileName;
     }
     return '';
+};
+const checkForBom = (module) => {
+    if (module.startsWith('\0')) {
+        return true;
+    }
+    return false;
 };
 var index = (options = {}) => {
     const moduleOptions = {

--- a/dist/index.es.js
+++ b/dist/index.es.js
@@ -150,7 +150,7 @@ const getJsImports = (code, absolutePath, pathResolver) => {
     const importStart = code.indexOf('import');
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !checkForBom(i.fromModule))
+            .filter(i => !hasBom(i.fromModule))
             .map(i => {
             const p = path.parse(i.fromModule);
             const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -292,8 +292,8 @@ const getBundleName = (bundle) => {
     }
     return '';
 };
-const checkForBom = (module) => {
-    if (module.startsWith('\0')) {
+const hasBom = (module) => {
+    if (!module.search(/\0/)) {
         return true;
     }
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ const getJsImports = (code: string, absolutePath: string, pathResolver: (string)
 
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !checkForBom(i.fromModule))
+            .filter(i => !hasBom(i.fromModule))
             .map(i => {
                 const p = path.parse(i.fromModule);
                 const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -368,8 +368,8 @@ const getBundleName = (bundle: Record<string, any>): string => {
     return '';
 }
 
-const checkForBom = (module: string):boolean => {
-    if (module.startsWith('\0')) {
+const hasBom = (module: string):boolean => {
+    if (!module.search(/\0/)) {
         return true;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,7 +190,7 @@ const getJsImports = (code: string, absolutePath: string, pathResolver: (string)
 
     if (importStart >= 0) {
         const imports = parseImports(code.substr(code.indexOf('import')))
-            .filter(i => !i.fromModule.startsWith('\\u0000'))
+            .filter(i => !checkForBom(i.fromModule))
             .map(i => {
                 const p = path.parse(i.fromModule);
                 const ext = p.ext ? p.ext.substr(1) : 'js';
@@ -366,6 +366,14 @@ const getBundleName = (bundle: Record<string, any>): string => {
     }
 
     return '';
+}
+
+const checkForBom = (module: string):boolean => {
+    if (module.startsWith('\0')) {
+        return true;
+    }
+
+    return false;
 }
 
 export default (options = {}) => {


### PR DESCRIPTION
changing the filter to a more generic null char that works for both instances (the null char in durango is in unicode, and in html it's represented as a byte? not exactly sure but this filter is equal to both)